### PR TITLE
Fix FOOL issue with free variables

### DIFF
--- a/CLAUSES/ccl_tformulae.c
+++ b/CLAUSES/ccl_tformulae.c
@@ -589,19 +589,19 @@ static void tformula_collect_freevars(TB_p bank, TFormula_p form, PTree_p *vars)
       tformula_collect_freevars(bank, form->args[1], vars);
       TermCellSetProp(form->args[0], old_prop);
    }
-   else if(TFormulaIsLiteral(bank->sig, form))
-   {
-      TermCollectPropVariables(form, vars, TPIsFreeVar);
-   }
    else
    {
-      if(TFormulaHasSubForm1(bank->sig,form))
+      for(int i=0; i<form->arity; i++)
       {
-         tformula_collect_freevars(bank, form->args[0], vars);
-      }
-      if(TFormulaHasSubForm2(bank->sig, form))
-      {
-         tformula_collect_freevars(bank, form->args[1], vars);
+         if(TermIsVar(form->args[i]) && 
+            TermCellQueryProp(form->args[i], TPIsFreeVar))
+         {
+            PTreeStore(vars, form->args[i]);
+         }
+         else 
+         {
+            tformula_collect_freevars(bank, form->args[i], vars);
+         }
       }
    }
 }

--- a/Makefile.vars
+++ b/Makefile.vars
@@ -15,8 +15,8 @@
 # executables. Edit it to point to wherever you want them to live.
 # Note that ./configure takes care of this automatically.
 
-EXECPATH = /Users/schulz/SOURCES/Projects/E/PROVER
-MANPATH = /Users/schulz/SOURCES/Projects/E/DOC/man
+EXECPATH = /home/petar/Documents/Projects/eprover/PROVER
+MANPATH = /home/petar/Documents/Projects/eprover/DOC/man
 STAREXECPATH=$(HOME)/StarExec
 
 # abstracting away from picosat version
@@ -117,7 +117,7 @@ BUILDFLAGS = -DPRINT_SOMEERRORS_STDOUT \
              -DSTACK_SIZE=32768 \
              -DCLAUSE_PERM_IDENT \
              -DTAGGED_POINTERS \
-             # -DENABLE_LFHO \
+             -DENABLE_LFHO \
 	     # -DUSE_NEWMEM \
              # -DCOMPILE_HEURISTICS_OPTIMIZED \
              # -DPDT_COUNT_NODES \
@@ -140,7 +140,7 @@ LTOFLAGS   = # -flto
 WFLAGS     = -Wall
 OPTFLAGS   = -O03 -fomit-frame-pointer -fno-common
 #OPTFLAGS   = -O3 -fno-common
-EHOH       =
+EHOH       = eprover-ho
 
 
 DEBUGFLAGS = $(PROFFLAGS) $(MEMDEBUG) $(DEBUGGER) $(NODEBUG)


### PR DESCRIPTION
FOOL/TFX (and HOL in general) allow quantified formulas in terms, which confuses the old code that assumes all variables in terms are free. The fix is to treat all terms as formulas (which is easy, since terms and formulas are a unified type, anyways)

Example to exercise the bug:

thf(ty_cname, type, (cname : $tType)).

thf(ty_creal, type, (creal : $tType)).

thf(ty_cstring, type, (cstring : $tType)).

thf(ty_cle_n97, type, (cle_n97 : (creal > creal > $o))).

thf(ty_cauto__param_n114, type, (cauto__param_n114 : ($o > cname > $o))).

thf(ty_cx_n118, type, (cx_n118 : cstring)).

thf(ty_clt_n126, type, (clt_n126 : (creal > creal > $o))).

thf(ty_cname_o_anonymous, type, (cname_o_anonymous : cname)).

thf(ty_cname_o_mk__string, type, (cname_o_mk__string : (cstring > cname > cname))).

thf(clt__iff__le__not__le_n446, axiom,
 (cauto__param_n114 @
  (![Xa_n447: creal]:
   (![Xb_n448: creal]:
    ((clt_n126 @ Xa_n447 @ Xb_n448) <=> ((cle_n97 @ Xa_n447 @ Xb_n448) & (~ (cle_n97 @ Xb_n448 @ Xa_n447)))))) @
  (cname_o_mk__string @ cx_n118 @ cname_o_anonymous))).
