### PR TITLE
Detailed Proofs

### DIFF
--- a/CLAUSES/ccl_derivation.c
+++ b/CLAUSES/ccl_derivation.c
@@ -1195,15 +1195,7 @@ void DerivationStackTSTPPrint(FILE* out, Sig_p sig, PStack_p derivation)
          PStackPushInt(subexpr_stack, i);
 
          op = PStackElementInt(derivation, i);
-         i++;
-         if(DCOpHasArg1(op))
-         {
-            i++;
-         }
-         if(DCOpHasArg2(op))
-         {
-            i++;
-         }
+         i += DCOpCountArgs(op) + 1;
       }
       /* Print the beginning of the subexpressions */
 

--- a/CLAUSES/ccl_derivation.c
+++ b/CLAUSES/ccl_derivation.c
@@ -1244,6 +1244,7 @@ void DerivationStackTSTPPrint(FILE* out, Sig_p sig, PStack_p derivation)
                        tstp_get_clauseform_id(op, 1, PStackElementP(derivation, i+1)));
                if(DCOpHasParentArg2(op))
                {
+                  /* TODO: what notation to use when printing two positions for a single argument? */
                   if (DCOpHasNumArg3(op))
                   {
                      fprintf(out, "@%ld", PStackElementInt(derivation, i+3));

--- a/CLAUSES/ccl_derivation.c
+++ b/CLAUSES/ccl_derivation.c
@@ -1244,21 +1244,35 @@ void DerivationStackTSTPPrint(FILE* out, Sig_p sig, PStack_p derivation)
                        tstp_get_clauseform_id(op, 1, PStackElementP(derivation, i+1)));
                if(DCOpHasParentArg2(op))
                {
-                  /* TODO: what notation to use when printing two positions for a single argument? */
+                  /* Position for argument 1 */
                   if (DCOpHasNumArg3(op))
                   {
-                     fprintf(out, "@%ld", PStackElementInt(derivation, i+3));
+                     fprintf(out, "@{%ld}", PStackElementInt(derivation, i+3));
                   }
+
                   fprintf(out, ", %s",
                           tstp_get_clauseform_id(op, 2, PStackElementP(derivation, i+2)));
+                  
+                  /* Position for argument 2 */
                   if (DCOpHasNumArg4(op))
                   {
-                     fprintf(out, "@%ld", PStackElementInt(derivation, i+4));
+                     fprintf(out, "@{%ld}", PStackElementInt(derivation, i+4));
                   }
                }
                else if(DCOpHasNumArg2(op))
                {
-                  fprintf(out, "@%ld", PStackElementInt(derivation, i+2));
+                  /* Position 1 for argument 1 */
+                  fprintf(out, "@{%ld", PStackElementInt(derivation, i+2));
+
+                  /* Position 2 for argument 1 */
+                  if(DCOpHasNumArg3(op))
+                  {
+                     fprintf(out, ",%ld}", PStackElementInt(derivation, i+3));
+                  }
+                  else
+                  {
+                     fprintf(out, "}");
+                  }
                }
             }
             while(!PStackEmpty(arg_stack))

--- a/CLAUSES/ccl_derivation.c
+++ b/CLAUSES/ccl_derivation.c
@@ -936,6 +936,14 @@ long DerivStackExtractOptParents(PStack_p derivation,
          {
             i++;
          }
+         if(DCOpHasArg3(op))
+         {
+            i++;
+         }
+         if(DCOpHasArg4(op))
+         {
+            i++;
+         }
          if(op==DCACRes)
          {
             //printf("ACRes: Numarg1: %ld\n", numarg1);
@@ -980,15 +988,7 @@ void DerivStackCountSearchInferences(PStack_p derivation,
       while(i<sp)
       {
          op = PStackElementInt(derivation, i);
-         i++;
-         if(DCOpHasArg1(op))
-         {
-            i++;
-         }
-         if(DCOpHasArg2(op))
-         {
-            i++;
-         }
+         i += DCOpCountArgs(op) + 1;
          switch(op)
          {
          case DCParamod:
@@ -1079,15 +1079,7 @@ void DerivationStackPCLPrint(FILE* out, Sig_p sig, PStack_p derivation)
          PStackPushInt(subexpr_stack, i);
 
          op = PStackElementInt(derivation, i);
-         i++;
-         if(DCOpHasArg1(op))
-         {
-            i++;
-         }
-         if(DCOpHasArg2(op))
-         {
-            i++;
-         }
+         i += DCOpCountArgs(op) + 1;
       }
       /* Print the beginning of the subexpressions */
 
@@ -1175,6 +1167,9 @@ void DerivationStackPCLPrint(FILE* out, Sig_p sig, PStack_p derivation)
 // Function: DerivationStackTSTPPrint()
 //
 //   Print the derivation stack as a TSTP expression.
+//   As an extension, positional information for the arguments is
+//   appended when provided, i.e. parent arg 1 + num arg 2, or
+//   parent arg 1 + parent arg 2 + num arg 3 + num arg 4.
 //
 // Global Variables: -
 //
@@ -1249,8 +1244,20 @@ void DerivationStackTSTPPrint(FILE* out, Sig_p sig, PStack_p derivation)
                        tstp_get_clauseform_id(op, 1, PStackElementP(derivation, i+1)));
                if(DCOpHasParentArg2(op))
                {
+                  if (DCOpHasNumArg3(op))
+                  {
+                     fprintf(out, "@%ld", PStackElementInt(derivation, i+3));
+                  }
                   fprintf(out, ", %s",
                           tstp_get_clauseform_id(op, 2, PStackElementP(derivation, i+2)));
+                  if (DCOpHasNumArg4(op))
+                  {
+                     fprintf(out, "@%ld", PStackElementInt(derivation, i+4));
+                  }
+               }
+               else if(DCOpHasNumArg2(op))
+               {
+                  fprintf(out, "@%ld", PStackElementInt(derivation, i+2));
                }
             }
             while(!PStackEmpty(arg_stack))

--- a/CLAUSES/ccl_derivation.h
+++ b/CLAUSES/ccl_derivation.h
@@ -141,8 +141,8 @@ typedef enum
    DCDistDisjunctions = DODistDisjunctions,
    DCAnnoQuestion     = DOAnnoQuestion,
    /* Generating inferences */
-   DCParamod          = DOParamod |Arg1Cnf|Arg2Cnf,
-   DCSimParamod       = DOSimParamod|Arg1Cnf|Arg2Cnf,
+   DCParamod          = DOParamod|Arg1Cnf|Arg2Cnf|Arg3Num|Arg4Num,
+   DCSimParamod       = DOSimParamod|Arg1Cnf|Arg2Cnf|Arg3Num|Arg4Num,
    DCOrderedFactor    = DOOrderedFactor|Arg1Cnf,
    DCEqFactor         = DOEqFactor|Arg1Cnf,
    DCEqRes            = DOEqRes|Arg1Cnf,

--- a/CLAUSES/ccl_derivation.h
+++ b/CLAUSES/ccl_derivation.h
@@ -24,6 +24,9 @@
 
 #define CCL_DERIVATION
 
+#include <stdarg.h>
+
+#include "ccl_clausecpos.h"
 #include <ccl_inferencedoc.h>
 #include <ccl_clauses.h>
 #include <ccl_formula_wrapper.h>
@@ -237,6 +240,12 @@ extern bool            ProofObjectRecordsGCSelection;
 #define DCOpHasParentArg4(op) ((op)&(Arg4Cnf|Arg4Fof))
 #define DCOpHasArg4(op)       ((op)&(Arg4Cnf|Arg4Fof|Arg4Num))
 
+#define DCOpHasCnfArgN(op,n)    ((op)&(Arg1Cnf<<(n)))
+#define DCOpHasFofArgN(op,n)    ((op)&(Arg1Fof<<(n)))
+#define DCOpHasNumArgN(op,n)    ((op)&(Arg1Num<<(n)))
+#define DCOpHasParentArgN(op,n) ((op)&((Arg1Cnf|Arg1Fof)<<(n)))
+#define DCOpHasArgN(op,n)       ((op)&((Arg1Cnf|Arg1Fof|Arg1Num)<<(n)))
+
 #define DCOpCountArgs(op)     ((DCOpHasArg1(op) != 0) + (DCOpHasArg2(op) != 0) \
                               + (DCOpHasArg3(op) != 0) + (DCOpHasArg4(op) != 0))
 
@@ -244,8 +253,7 @@ extern bool            ProofObjectRecordsGCSelection;
 #define DCOpIsGenerating(op) ((DPOpGetOpCode(op) >= DOParamod)&&(DPOpGetOpCode(op) <= DOSatGen))
 
 
-void ClausePushDerivation(Clause_p clause, DerivationCode op,
-                          void* arg1, void* arg2);
+void ClausePushDerivation(Clause_p clause, DerivationCode op, ...);
 
 void ClausePushACResDerivation(Clause_p clause, Sig_p sig);
 

--- a/CLAUSES/ccl_derivation.h
+++ b/CLAUSES/ccl_derivation.h
@@ -143,9 +143,9 @@ typedef enum
    /* Generating inferences */
    DCParamod          = DOParamod|Arg1Cnf|Arg2Cnf|Arg3Num|Arg4Num,
    DCSimParamod       = DOSimParamod|Arg1Cnf|Arg2Cnf|Arg3Num|Arg4Num,
-   DCOrderedFactor    = DOOrderedFactor|Arg1Cnf,
-   DCEqFactor         = DOEqFactor|Arg1Cnf,
-   DCEqRes            = DOEqRes|Arg1Cnf,
+   DCOrderedFactor    = DOOrderedFactor|Arg1Cnf|Arg2Num,
+   DCEqFactor         = DOEqFactor|Arg1Cnf|Arg2Num,
+   DCEqRes            = DOEqRes|Arg1Cnf|Arg2Num,
    DCSatGen           = DOSatGen|Arg1Cnf,
    /* CNF conversion and similar */
    DCSplitEquiv       = DOSplitEquiv|Arg1Fof,

--- a/CLAUSES/ccl_derivation.h
+++ b/CLAUSES/ccl_derivation.h
@@ -143,8 +143,8 @@ typedef enum
    /* Generating inferences */
    DCParamod          = DOParamod|Arg1Cnf|Arg2Cnf|Arg3Num|Arg4Num,
    DCSimParamod       = DOSimParamod|Arg1Cnf|Arg2Cnf|Arg3Num|Arg4Num,
-   DCOrderedFactor    = DOOrderedFactor|Arg1Cnf|Arg2Num,
-   DCEqFactor         = DOEqFactor|Arg1Cnf|Arg2Num,
+   DCOrderedFactor    = DOOrderedFactor|Arg1Cnf|Arg2Num|Arg3Num,
+   DCEqFactor         = DOEqFactor|Arg1Cnf|Arg2Num|Arg3Num,
    DCEqRes            = DOEqRes|Arg1Cnf|Arg2Num,
    DCSatGen           = DOSatGen|Arg1Cnf,
    /* CNF conversion and similar */

--- a/CLAUSES/ccl_derivation.h
+++ b/CLAUSES/ccl_derivation.h
@@ -237,6 +237,9 @@ extern bool            ProofObjectRecordsGCSelection;
 #define DCOpHasParentArg4(op) ((op)&(Arg4Cnf|Arg4Fof))
 #define DCOpHasArg4(op)       ((op)&(Arg4Cnf|Arg4Fof|Arg4Num))
 
+#define DCOpCountArgs(op)     ((DCOpHasArg1(op) != 0) + (DCOpHasArg2(op) != 0) \
+                              + (DCOpHasArg3(op) != 0) + (DCOpHasArg4(op) != 0))
+
 #define DPOpGetOpCode(op)  ((op)&127)
 #define DCOpIsGenerating(op) ((DPOpGetOpCode(op) >= DOParamod)&&(DPOpGetOpCode(op) <= DOSatGen))
 

--- a/CLAUSES/ccl_derivation.h
+++ b/CLAUSES/ccl_derivation.h
@@ -101,6 +101,12 @@ typedef enum
    Arg2Fof = 1<<11,
    Arg2Cnf = 1<<12,
    Arg2Num = 1<<13,
+   Arg3Fof = 1<<14,
+   Arg3Cnf = 1<<15,
+   Arg3Num = 1<<16,
+   Arg4Fof = 1<<17,
+   Arg4Cnf = 1<<18,
+   Arg4Num = 1<<19,
 }ArgDesc;
 
 
@@ -218,6 +224,18 @@ extern bool            ProofObjectRecordsGCSelection;
 #define DCOpHasNumArg2(op)    ((op)&Arg2Num)
 #define DCOpHasParentArg2(op) ((op)&(Arg2Cnf|Arg2Fof))
 #define DCOpHasArg2(op)       ((op)&(Arg2Cnf|Arg2Fof|Arg2Num))
+
+#define DCOpHasCnfArg3(op)    ((op)&Arg3Cnf)
+#define DCOpHasFofArg3(op)    ((op)&Arg3Fof)
+#define DCOpHasNumArg3(op)    ((op)&Arg3Num)
+#define DCOpHasParentArg3(op) ((op)&(Arg3Cnf|Arg3Fof))
+#define DCOpHasArg3(op)       ((op)&(Arg3Cnf|Arg3Fof|Arg3Num))
+
+#define DCOpHasCnfArg4(op)    ((op)&Arg4Cnf)
+#define DCOpHasFofArg4(op)    ((op)&Arg4Fof)
+#define DCOpHasNumArg4(op)    ((op)&Arg4Num)
+#define DCOpHasParentArg4(op) ((op)&(Arg4Cnf|Arg4Fof))
+#define DCOpHasArg4(op)       ((op)&(Arg4Cnf|Arg4Fof|Arg4Num))
 
 #define DPOpGetOpCode(op)  ((op)&127)
 #define DCOpIsGenerating(op) ((DPOpGetOpCode(op) >= DOParamod)&&(DPOpGetOpCode(op) <= DOSatGen))

--- a/CONTROL/cco_eqnresolving.c
+++ b/CONTROL/cco_eqnresolving.c
@@ -85,7 +85,7 @@ long ComputeAllEqnResolvents(TB_p bank, Clause_p clause, ClauseSet_p
        ClauseSetTPTPType(resolvent, ClauseQueryTPTPType(clause));
        ClauseSetProp(resolvent, ClauseGiveProps(clause, CPIsSOS));
        DocClauseCreationDefault(resolvent, inf_eres, clause, NULL);
-            ClausePushDerivation(resolvent, DCEqRes, clause, NULL);
+            ClausePushDerivation(resolvent, DCEqRes, clause, PackClausePos(pos));
        ClauseSetInsert(store, resolvent);
     }
     test = ClausePosNextEqResLiteral(pos);

--- a/CONTROL/cco_factoring.c
+++ b/CONTROL/cco_factoring.c
@@ -86,7 +86,7 @@ long ComputeAllOrderedFactors(TB_p bank, OCB_p ocb,
        ClauseSetTPTPType(factor, ClauseQueryTPTPType(clause));
        ClauseSetProp(factor, ClauseGiveProps(clause, CPIsSOS));
        DocClauseCreationDefault(factor, inf_factor,clause,NULL);
-            ClausePushDerivation(factor, DCOrderedFactor, clause, NULL);
+            ClausePushDerivation(factor, DCOrderedFactor, clause, PackClausePos(pos1), PackClausePos(pos2));
        ClauseSetInsert(store, factor);
     }
     test = ClausePosNextOrderedFactorLiterals(pos1, pos2);
@@ -138,7 +138,7 @@ long ComputeAllEqualityFactors(TB_p bank, OCB_p ocb,
        ClauseSetTPTPType(factor, ClauseQueryTPTPType(clause));
        ClauseSetProp(factor, ClauseGiveProps(clause, CPIsSOS));
        DocClauseCreationDefault(factor, inf_efactor, clause, NULL);
-       ClausePushDerivation(factor, DCEqFactor, clause, NULL);
+       ClausePushDerivation(factor, DCEqFactor, clause, PackClausePos(pos1), PackClausePos(pos2));
        ClauseSetInsert(store, factor);
     }
     test = ClausePosNextEqualityFactorSides(pos1, pos2);

--- a/CONTROL/cco_paramodulation.c
+++ b/CONTROL/cco_paramodulation.c
@@ -253,7 +253,7 @@ static long compute_into_pm_pos_clause(ParamodInfo_p pminfo,
                                      pminfo->into,
                                      pminfo->new_orig);
             ClausePushDerivation(clause,  pm_type==ParamodPlain?DCParamod:DCSimParamod,
-                                 pminfo->into, pminfo->new_orig);
+                                 pminfo->into, pminfo->new_orig, pminfo->from_cpos, pminfo->into_cpos);
          }
       }
       ClausePosFree(pminfo->into_pos);
@@ -470,7 +470,7 @@ static long compute_from_pm_pos_clause(ParamodInfo_p pminfo,
                                      pminfo->new_orig,
                                      pminfo->from);
             ClausePushDerivation(clause,  pm_type?DCSimParamod:DCParamod,
-                                 pminfo->new_orig, pminfo->from);
+                                 pminfo->new_orig, pminfo->from, pminfo->into_cpos, pminfo->from_cpos);
          }
       }
       ClausePosFree(pminfo->from_pos);
@@ -707,7 +707,7 @@ long ComputeClauseClauseParamodulants(TB_p bank, OCB_p ocb, Clause_p
               parent_alias);
          ClausePushDerivation(clause,
                               inf_type==inf_sim_paramod?DCSimParamod:DCParamod,
-                              with, parent_alias);
+                              with, parent_alias, PackClausePos(pos2), PackClausePos(pos1));
     ClauseSetInsert(store, paramod);
       }
       test = ClausePosNextParamodPair(pos1, pos2, false, pm_type != ParamodPlain);
@@ -752,7 +752,7 @@ long ComputeClauseClauseParamodulants(TB_p bank, OCB_p ocb, Clause_p
        DocClauseCreationDefault(paramod, inf_type, parent_alias, with);
             ClausePushDerivation(clause,
                                  inf_type==inf_sim_paramod?DCSimParamod:DCParamod,
-                                 parent_alias, with);
+                                 parent_alias, with, PackClausePos(pos1), PackClausePos(pos2));
        ClauseSetInsert(store, paramod);
     }
     test = ClausePosNextParamodPair(pos1, pos2, true, pm_type != ParamodPlain);


### PR DESCRIPTION
This pull request introduces positional annotations to the TSTP proof output.

The compact positions of an opcode's arguments in a derivation are stored as additional numeric arguments. Currently, only the generating inferences are augmented with positional information, but the storage and output code do support arbitrary opcodes.

**Due to my lack of experience with this project I wasn't able to conduct exhaustive testing of my feature. If you could point me to a problem that triggers triggers the `DCEqFactor` and `DCOrderedFactor` opcodes, this would allow me to test whether two positions for a single argument are properly displayed.**