### PR TITLE
Update eprover.c

### DIFF
--- a/PROVER/eprover.c
+++ b/PROVER/eprover.c
@@ -280,12 +280,6 @@ static void print_info(void)
 
 void strategy_io(HeuristicParms_p h_parms, PStack_p hcb_definitions)
 {
-   if(print_strategy)
-   {
-      HeuristicParmsPrint(stdout, h_parms);
-      exit(NO_ERROR);
-   }
-
    if(parse_strategy_filename)
    {
       Scanner_p in = CreateScanner(StreamTypeFile, parse_strategy_filename,
@@ -296,6 +290,12 @@ void strategy_io(HeuristicParms_p h_parms, PStack_p hcb_definitions)
          PStackPushP(hcb_definitions, h_parms->heuristic_def);
       }
       DestroyScanner(in);
+   }
+
+   if(print_strategy)
+   {
+      HeuristicParmsPrint(stdout, h_parms);
+      exit(NO_ERROR);
    }
 }
 


### PR DESCRIPTION
in strategy_io I propose switching the order of those ifs so that you can get the auto strategy by calling E with --auto and --print-strategy. Currently I don't think it works that way unless I'm missing something.