### PR TITLE
Strategy_io can print its loaded strategy and also print auto now?

### DIFF
--- a/PROVER/eprover.c
+++ b/PROVER/eprover.c
@@ -280,12 +280,6 @@ static void print_info(void)
 
 void strategy_io(HeuristicParms_p h_parms, PStack_p hcb_definitions)
 {
-   if(print_strategy)
-   {
-      HeuristicParmsPrint(stdout, h_parms);
-      exit(NO_ERROR);
-   }
-
    if(parse_strategy_filename)
    {
       Scanner_p in = CreateScanner(StreamTypeFile, parse_strategy_filename,
@@ -296,6 +290,12 @@ void strategy_io(HeuristicParms_p h_parms, PStack_p hcb_definitions)
          PStackPushP(hcb_definitions, h_parms->heuristic_def);
       }
       DestroyScanner(in);
+   }
+
+   if(print_strategy)
+   {
+      HeuristicParmsPrint(stdout, h_parms);
+      exit(NO_ERROR);
    }
 }
 
@@ -551,7 +551,6 @@ int main(int argc, char* argv[])
 
    print_info();
 
-   strategy_io(h_parms, hcb_definitions);
 
    proofstate = parse_spec(state, parse_format,
                            error_on_empty, free_symb_prop,
@@ -783,6 +782,8 @@ int main(int argc, char* argv[])
       state = process_options(argc, argv); // refilling the h_parms with user options
       h_parms->heuristic_name = h_parms->heuristic_def;
    }
+
+   strategy_io(h_parms, hcb_definitions);
 
    if(limits)
    {


### PR DESCRIPTION
Feel free to reject if you think this is bad, but the goal of this commit is to make strategy_io called *after* --auto chooses a strategy. That way  --auto strategies can be printed. I also swapped the order of parsing and printing in strategy_io so that a parsed strategy can be printed to confirm it was processed.