### PR TITLE
Added parse error recovery (panic mode)

### DIFF
--- a/BASICS/clb_error.c
+++ b/BASICS/clb_error.c
@@ -111,6 +111,29 @@ void Error(char* message, ErrorCodes ret, ...)
    exit(ret);
 }
 
+/*-----------------------------------------------------------------------
+//
+// Function: PrintError()
+//
+//   Print an error message to stderr.
+//
+// Global Variables: ProgName
+//
+// Side Effects    : -
+//
+/----------------------------------------------------------------------*/
+
+void PrintError(char* message, ErrorCodes ret, ...)
+{
+   va_list ap;
+   va_start(ap, ret);
+
+   fprintf(stderr, "%s: ", ProgName);
+   vfprintf(stderr, message, ap);
+   fprintf(stderr, "\n");
+   va_end(ap);
+}
+
 
 /*-----------------------------------------------------------------------
 //

--- a/BASICS/clb_error.h
+++ b/BASICS/clb_error.h
@@ -81,6 +81,7 @@ void          InitError(char* progname);
 void          Error(char* message, ErrorCodes ret, ...);
 void          SysError(char* message, ErrorCodes ret, ...);
 void          Warning(char* message, ...);
+void          PrintError(char* message, ErrorCodes ret, ...);
 void          SysWarning(char* message, ...);
 void          ELog(char* message, ...);
 double        GetTotalCPUTime(void);

--- a/INOUT/cio_scanner.c
+++ b/INOUT/cio_scanner.c
@@ -645,6 +645,37 @@ static void compose_errmsg(DStr_p err, Scanner_p in, char* msg)
 
 /*-----------------------------------------------------------------------
 //
+// Function: panic_mode()
+//
+//    If a synchronization token is expected, skip input until one is hit.
+//
+// Global Variables: -
+//
+// Side Effects    : -
+//
+/----------------------------------------------------------------------*/
+
+static void panic_mode(Scanner_p in, TokenType toks)
+{
+   /* Read input until the token is hit. */
+   if (toks & SyncTokens)
+   {
+      while(!TestInpTok(in, toks))
+      {
+         NextToken(in);
+      }
+
+      /* Skip the sync token. */
+      NextToken(in);
+
+      /* Leave the panic mode. */
+      in->panic_mode = false;
+   }
+}
+
+
+/*-----------------------------------------------------------------------
+//
 // Function: str_n_element()
 //
 //   Test whether the len lenght start of str is contained in the set
@@ -848,6 +879,7 @@ Scanner_p CreateScanner(StreamType type, char *name, bool
    handle->ignore_comments = ignore_comments;
    handle->include_key = NULL;
    handle->format = LOPFormat;
+   handle->panic_mode = false;
 
    //printf("# CreateScanner(%s, %s, %d, %s, %d)\n", type, name,
    //ignore_comments, default_dir, fail);
@@ -1101,24 +1133,23 @@ bool TestIdnum(Token_p akt, char* ids)
 //
 // Global Variables: -
 //
-// Side Effects    : Terminates program
+// Side Effects    : -
 //
 /----------------------------------------------------------------------*/
 
 void AktTokenError(Scanner_p in, char* msg, bool syserr)
 {
+   /* Do not throw new errors while in panic mode. */
+   if (in->panic_mode) return;
+
+   /* Enter panic mode. */
+   in->panic_mode = true;
+
    DStr_p err = DStrAlloc();
 
    compose_errmsg(err, in, msg);
-   if(syserr)
-   {
-      SysError(DStrView(err), SYNTAX_ERROR);
-   }
-   else
-   {
-      Error(DStrView(err), SYNTAX_ERROR);
-   }
-   DStrFree(err); /* Just for symmetry reasons */
+   PrintError(DStrView(err), SYNTAX_ERROR);
+   DStrFree(err);
 }
 
 
@@ -1131,12 +1162,18 @@ void AktTokenError(Scanner_p in, char* msg, bool syserr)
 //
 // Global Variables: -
 //
-// Side Effects    : Terminates program
+// Side Effects    : -
 //
 /----------------------------------------------------------------------*/
 
 void AktTokenWarning(Scanner_p in, char* msg)
 {
+   /* Do not throw new errors while in panic mode. */
+   if (in->panic_mode) return;
+
+   /* Enter panic mode. */
+   in->panic_mode = true;
+
    DStr_p err = DStrAlloc();
 
    compose_errmsg(err, in, msg);
@@ -1153,7 +1190,7 @@ void AktTokenWarning(Scanner_p in, char* msg)
 //
 // Global Variables: -
 //
-// Side Effects    : Memory operations, may terminate program.
+// Side Effects    : -
 //
 /----------------------------------------------------------------------*/
 
@@ -1186,7 +1223,7 @@ void CheckInpTok(Scanner_p in, TokenType toks)
 //
 // Global Variables: -
 //
-// Side Effects    : As CheckInpTok()
+// Side Effects    : -
 //
 /----------------------------------------------------------------------*/
 
@@ -1220,7 +1257,7 @@ void CheckInpTokNoSkip(Scanner_p in, TokenType toks)
 //
 // Global Variables: -
 //
-// Side Effects    : Memory operations, may terminate program.
+// Side Effects    : -
 //
 /----------------------------------------------------------------------*/
 
@@ -1240,6 +1277,64 @@ void CheckInpId(Scanner_p in, char* ids)
       DStrAppendStr(in->accu, DStrView(AktToken(in)->literal));
       DStrAppendStr(in->accu, "') read ");
       AktTokenError(in, DStrView(in->accu), false);
+   }
+}
+
+
+/*-----------------------------------------------------------------------
+//
+// Function:  AcceptInpTok()
+//
+//   Checks with CheckInpTok(in) if the current token is one of the
+//   desired types. Consumes the token if it is. Also handles error 
+//   recovery.
+//
+// Global Variables: -
+//
+// Side Effects    : -
+//
+/----------------------------------------------------------------------*/
+
+void AcceptInpTok(Scanner_p in, TokenType toks)
+{
+   CheckInpTok(in, toks);
+
+   /* Handle panic mode. */
+   if(in->panic_mode)
+   {
+      panic_mode(in, toks);
+   }
+   else
+   {
+      NextToken(in);
+   }
+}
+
+
+/*-----------------------------------------------------------------------
+//
+// Function:  AcceptInpTokNoSkip()
+//
+//   Same as AcceptInpTok() but with CheckInpTokNoSkip().
+//
+// Global Variables: -
+//
+// Side Effects    : -
+//
+/----------------------------------------------------------------------*/
+
+void AcceptInpTokNoSkip(Scanner_p in, TokenType toks)
+{
+   CheckInpTokNoSkip(in, toks);
+
+   /* Handle panic mode. */
+   if(in->panic_mode)
+   {
+      panic_mode(in, toks);
+   }
+   else
+   {
+      NextToken(in);
    }
 }
 

--- a/INOUT/cio_scanner.h
+++ b/INOUT/cio_scanner.h
@@ -103,6 +103,9 @@ typedef unsigned long long TokenType;
 #define FOFBinOp      (FOFAnd|FOFOr|FOFLRImpl|FOFRLImpl|FOFEquiv|FOFXor|FOFNand|FOFNor|EqualSign|NegEqualSign)
 #define FOFAssocOp    (FOFAnd|FOFOr)
 
+/* Tokens used to synchronize error recovery (panic mode): */
+#define SyncTokens    (Fullstop)
+
 
 
 /* If your application parses multiple format you can use this to
@@ -154,6 +157,7 @@ typedef struct scannercell
    TokenCell   tok_sequence[MAXTOKENLOOKAHEAD]; /* Need help? Bozo! */
    int         current; /* Pointer to current token in tok_sequence */
    char*       include_pos; /* If created by "include", by which one? */
+   bool        panic_mode; /* Has there been a parsing error? */
 }ScannerCell, *Scanner_p;
 
 
@@ -218,13 +222,9 @@ void AktTokenWarning(Scanner_p in, char* msg);
 void CheckInpTok(Scanner_p in, TokenType toks);
 void CheckInpTokNoSkip(Scanner_p in, TokenType toks);
 void CheckInpId(Scanner_p in, char* ids);
+void AcceptInpTok(Scanner_p in, TokenType toks);
+void AcceptInpTokNoSkip(Scanner_p in, TokenType toks);
 
-
-#define AcceptInpTok(in, toks) CheckInpTok((in), (toks));\
-                               NextToken(in)
-#define AcceptInpTokNoSkip(in, toks) \
-                               CheckInpTokNoSkip((in), (toks));\
-                               NextToken(in)
 #define AcceptInpId(in, ids)   CheckInpId((in), (ids));\
                                NextToken(in)
 


### PR DESCRIPTION
Hallo,

ist schon ein Weilchen her, aber bin neulich wieder ueber dieses wunderschoene Projekt gestolpert.

Habe hier die einfachste Form der Parse-Error-Recovery implementiert: den Panic-Mode. D.h. wird ein falsches Token gelesen, wird die komplette Clause bis zum naechsten `FullStop` eingelesen, um Domino-Fehler zu minimieren.

Einfaches Beispiel:
```
fof(wealldie,      axiom, ![X]:(human(X) => mortal(X))).
fof(socrateshuman, axom, ![X]:(human(socrates))).  // axiom -> axom
fof(socratesdies,  cojecture, mortal(socrates)).  // conjecture -> cojecture
```

Der Output (natuerlich wird hier kein Beweis gefunden):
```
/eprover ../EXAMPLE_PROBLEMS/SMOKETEST/socrates.p 
eprover: ../EXAMPLE_PROBLEMS/SMOKETEST/socrates.p:2:(Column 20):(just read 'axom'): Identifier (axiom|hypothesis|definitio
n|assumption|lemma|theorem|conjecture|question|negated_conjecture|plain|unknown) expected, but Identifier not terminating in a number('axom') read 
eprover: ../EXAMPLE_PROBLEMS/SMOKETEST/socrates.p:3:(Column 20):(just read 'cojecture'): Identifier (axiom|hypothesis|definition|assumption|lemma|theorem|conjecture|question|negated_conjecture|plain|unknown) expected, but Identifier not terminating in a number('cojecture') read 
# Initializing proof state
# Scanning for AC axioms
#
#cnf(i_0_2, plain, (axom)).
#
#cnf(i_0_3, plain, (cojecture)).
#
#cnf(i_0_1, plain, (mortal(X1)|~human(X1))).

# No proof found!
...
```

Ich hoffe der Code passt so einigermassen, damit meine alte Projektarbeit doch noch irgendwann einen Weg in den main findet :)