### PR TITLE
Fix owner_bank lost in TermCopyRenameVars and TermCopyUnifyVars

### DIFF
--- a/TERMS/cte_termfunc.c
+++ b/TERMS/cte_termfunc.c
@@ -3190,6 +3190,7 @@ Term_p TermCopyRenameVars(NumTree_p* renaming, Term_p term)
     {
         copy = TermTopCopy(term);
         copy->type = term->type;
+        TermSetBank(copy, TermGetBank(term));
         for (i=0; i<term->arity; i++)
         {
             copy->args[i] = TermCopyRenameVars(renaming, term->args[i]);
@@ -3250,6 +3251,7 @@ Term_p TermCopyUnifyVars(VarBank_p vars, Term_p term)
     }
 
     Term_p new = TermTopCopy(term);
+    TermSetBank(new, TermGetBank(term));
     for (i=0; i<term->arity; i++)
     {
         new->args[i] = TermCopyUnifyVars(vars, term->args[i]);


### PR DESCRIPTION
### Problem

In HO mode, `TermTopCopy` zeros out the `owner_bank` field on the copied term.
`NormalizePatternAppVar` (called during HO inference) asserts that `owner_bank`
is set on any applied variable term it processes.

`TermCopyRenameVars` and `TermCopyUnifyVars` both call `TermTopCopy` but never
restored `owner_bank` on the copy, causing an assertion failure:

```
eprover: cte_ho_csu.c:106: NormalizePatternAppVar: Assertion `bank' failed.
```

### Affected problems

- TPTP `ALG247^2` (higher-order algebra)
- TPTP `SYO548^1` (higher-order synthesis)

### Minimal reproducer

Save as `bug.p` and run `eprover-ho -H'(1*ConjectureTermPrefixWeight(DeferSOS,1,3,0.1,5,0,0.1,1,4))' bug.p`:

```tptp
thf(conj, conjecture,
    ? [Q: $i > $o, X: $i] : ( Q @ X )).
```

### Fix

In `TERMS/cte_termfunc.c`, add `TermSetBank(copy, TermGetBank(term))` immediately
after each `TermTopCopy` call in `TermCopyRenameVars` and `TermCopyUnifyVars`.

This mirrors the existing pattern in `TermCopyInsert` (line ~1362) and
`TermTopCopyWithoutArgs`-based callers that already restore `owner_bank`.
