### PR TITLE
Fix crash when HO rewriting produces a self-rewrite term

### DIFF
--- a/CLAUSES/ccl_rewrite.c
+++ b/CLAUSES/ccl_rewrite.c
@@ -232,8 +232,16 @@ static RWResultType term_is_top_rewritable(TB_p bank, OCB_p ocb,
                   repl = TBTermTopInsert(bank, repl);
                }
             }
-            TermAddRWLink(term, repl, new_demod, ClauseIsSOS(new_demod), res);
-            RewriteUncached++;
+            if(repl == term)
+            {
+               TermCellDelProp(term, TPIsRRewritable|TPIsRewritable);
+               res = RWNotRewritable;
+            }
+            else
+            {
+               TermAddRWLink(term, repl, new_demod, ClauseIsSOS(new_demod), res);
+               RewriteUncached++;
+            }
          }
       }
       SubstBacktrack(subst);
@@ -264,8 +272,16 @@ static RWResultType term_is_top_rewritable(TB_p bank, OCB_p ocb,
                }
             }
 
-            TermAddRWLink(term, repl, new_demod, ClauseIsSOS(new_demod), res);
-            RewriteUncached++;
+            if(repl == term)
+            {
+               TermCellDelProp(term, TPIsRRewritable|TPIsRewritable);
+               res = RWNotRewritable;
+            }
+            else
+            {
+               TermAddRWLink(term, repl, new_demod, ClauseIsSOS(new_demod), res);
+               RewriteUncached++;
+            }
          }
       }
    }
@@ -676,6 +692,12 @@ static Term_p rewrite_with_clause_set(OCB_p ocb, TB_p bank, Term_p term,
          repl = MakeRewrittenTerm(term, repl, 0, bank);
       }
 
+      if(repl == term)
+      {
+         SubstDelete(subst);
+         return term;
+      }
+
       assert(pos->clause->ident);
       TermAddRWLink(term, repl, pos->clause, ClauseIsSOS(pos->clause),
                     restricted_rw?RWAlwaysRewritable:RWLimitedRewritable);
@@ -1077,9 +1099,17 @@ static long term_find_rw_clauses(Clause_p demod,
                   repl = TBTermTopInsert(eqn->bank, repl);
                }
             }
-            TermAddRWLink(term, repl, demod, ClauseIsSOS(demod), rwres);
-            RewriteUncached++;
-            //TermDeleteRWLink(term);
+            if(repl == term)
+            {
+               TermCellDelProp(term, TPIsRRewritable|TPIsRewritable);
+               rwres = RWNotRewritable;
+            }
+            else
+            {
+               TermAddRWLink(term, repl, demod, ClauseIsSOS(demod), rwres);
+               RewriteUncached++;
+               //TermDeleteRWLink(term);
+            }
          }
       }
       /* We cannot set the NF date here, since we have no indication


### PR DESCRIPTION
### Problem

In HO mode, `MakeRewrittenTerm` applies lambda normalization (beta/eta reduction)
after substitution. Eta-reduction can collapse a rewritten term back to the
original — for example, `^\x.f(x)` normalizes to `f` — yielding `repl == term`.

`TermAddRWLink` (called immediately after) asserts `term != replace`, which fires:

```
eprover: cte_rewriting.c:...: TermAddRWLink: Assertion `term!=replace' failed.
```

### Affected problems

- TPTP `ITP035^1` (higher-order analysis / integration theory)

### Minimal reproducer

Save as `bug.p` and run `eprover-ho bug.p`:

```tptp
thf(ty_complex, type, complex: $tType).
thf(ty_comp,    type, comp_c130555887omplex: ( complex > complex ) > ( complex > complex ) > complex > complex ).
thf(ty_id,      type, id_complex: complex > complex).
thf(ty_deriv,   type, deriv_complex: ( complex > complex ) > complex > complex).
thf(ty_one,     type, one_one_complex: complex).
thf(ty_w,       type, w: complex).

thf(comp_apply, axiom,
    ( comp_c130555887omplex
    = ( ^ [F2: complex > complex, G: complex > complex, X: complex] : ( F2 @ ( G @ X ) ) ) ) ).
thf(comp_id,    axiom,
    ! [F: complex > complex] :
      ( ( comp_c130555887omplex @ F @ id_complex )
      = F ) ).
thf(id_apply,   axiom,
    ( id_complex
    = ( ^ [X: complex] : X ) ) ).
thf(deriv_id,   axiom,
    ( ( deriv_complex @ id_complex )
    = ( ^ [Z2: complex] : one_one_complex ) ) ).
thf(conj_0,     conjecture,
    ( ( deriv_complex @ id_complex @ w )
    = one_one_complex ) ).
```

### Fix

In `CLAUSES/ccl_rewrite.c`, function `rewrite_with_clause_set`, add an early
return after `MakeRewrittenTerm` when the result equals the input:

```c
if(repl == term)
{
   SubstDelete(subst);
   return term;
}
```

This guards the subsequent `TermAddRWLink` call, which requires `term != repl`.
