### PR TITLE
Fix false assertion in indexed_find_demodulator for HO mode

### DIFF
--- a/CLAUSES/ccl_rewrite.c
+++ b/CLAUSES/ccl_rewrite.c
@@ -616,6 +616,7 @@ ClausePos_p indexed_find_demodulator(OCB_p ocb, Term_p term,
 
 #ifndef NDEBUG
    if(res
+      && problemType != PROBLEM_HO
       && !TermStructPrefixEqual(ClausePosGetSide(res), term, DEREF_ONCE, DEREF_NEVER,
                                 0, ocb->sig))
    {


### PR DESCRIPTION
### Problem

Running `eprover-ho` on the TPTP problem ITP109^1 crashes immediately:

```
eprover: ccl_rewrite.c:632: indexed_find_demodulator: Assertion `false' failed.
```

The debug output printed before the crash shows:

```
Term groups1862963056a_real @ ($db_lam @ db(0) @ (groups1862963056a_real @ ($db_lam @ db(0) @
($@_var @ X447 @ db(0) @ db(1))) @ X55)) @ X126
derefed { groups1862963056a_real @ ($db_lam @ db(0) @ (groups1862963056a_real @ ($db_lam @ db(0) @
($@_var @ ($db_lam @ db(0) @ ($db_lam @ db(0) @ ($@_var @ X57 @ db(1)))) @ db(0) @ db(1))) @ X55)) @ X126 }
should match groups1862963056a_real @ ($db_lam @ db(0) @ (groups1862963056a_real @ X57 @ X55)) @ X126,
substitution is : {X447<-^[Z0:a, Z1:a]:(X57 @ Z0), X55<-X55, X126<-X126}.
```

### Affected problems

- TPTP `ITP109^1` (Interactive Theorem Proving / Lower_Semicontinuous)

### Minimal reproducer

```sh
eprover-ho ITP109^1.p
```

(No special flags needed; crashes with the default invocation.)

A 4-formula synthetic reproducer that also triggers the crash (no ITP problem needed):

```tptp
thf(sy_sum,type, sum: ( a > a ) > set_a > a).
thf(sy_op,type, op: a > a > a).

thf(ax1,axiom,
    ! [F: a > a,G: a > a,A: set_a] :
      ( ( sum @ ^ [X: a] : ( op @ ( F @ X ) @ ( G @ X ) ) @ A )
      = ( op @ ( sum @ F @ A ) @ ( sum @ G @ A ) ) ) ).

thf(ax2,axiom,
    ! [A: set_a,G: a > a > a] :
      ( ( sum @ ^ [X: a] : ( sum @ ( G @ X ) @ A ) @ A )
      = ( sum @ ^ [Y: a] : ( sum @ ^ [X: a] : ( G @ X @ Y ) @ A ) @ A ) ) ).
```

`ax1` (sum distributes over `op`) becomes the demodulator. `ax2` (Fubini/swap for double
sums) provides the target term. E applies `ax1` to the subterm
`sum(^[Y]. sum(G(Y), A), A)` from `ax2`; the HO unifier binds a demodulator variable to
a lambda, creating the beta redex that `TermStructPrefixEqual` fails to reduce.

### Root cause

The assertion at `ccl_rewrite.c:617–633` verifies that the demodulator found by
`PDTreeFindNextDemodulator` structurally matches the target term:

```c
if(res
   && !TermStructPrefixEqual(ClausePosGetSide(res), term, DEREF_ONCE, DEREF_NEVER, 0, ocb->sig))
{
   ...
   assert(false);
}
```

In HO mode, a valid demodulator match can produce a substitution where the demodulator
LHS contains lambda redexes that only equal the target term after full beta-normalization.
`TermStructPrefixEqual` with `DEREF_ONCE`/`DEREF_NEVER` does not perform full
beta-normalization, so it incorrectly reports a mismatch and the assertion fires.

The actual rewriting logic is correct: `MakeRewrittenTerm` (guarded by
`if(problemType == PROBLEM_HO)`) applies lambda normalization and produces the right
result. Only the debug sanity check uses an incomplete comparison for HO terms.

Note: `NDEBUG` is not defined in normal builds, so this fires in production.

### Fix

In `CLAUSES/ccl_rewrite.c`, guard the debug assertion with `problemType != PROBLEM_HO`
so it only fires in FO mode (where `DEREF_ONCE` is sufficient for structural comparison):

```c
#ifndef NDEBUG
   if(res
      && problemType != PROBLEM_HO
      && !TermStructPrefixEqual(ClausePosGetSide(res), term, DEREF_ONCE, DEREF_NEVER,
                                0, ocb->sig))
   {
      ...
      assert(false);
   }
#endif
```

This follows the existing pattern in `ccl_rewrite.c` of using `problemType != PROBLEM_HO`
runtime checks for HO-specific behaviour (e.g., lines 209, 227, 258, 674).
