### PR TITLE
Fix WHNF cache use-after-free via cross-bank pollution in TBInsertNoP…

### DIFF
--- a/TERMS/cte_lambda.c
+++ b/TERMS/cte_lambda.c
@@ -1155,6 +1155,7 @@ Term_p whnf_step_uncached(TB_p bank, Term_p t)
    res = new_matrix;
 
    PStackFree(to_bind_stack);
+   assert(TermIsShared(res));
    TermSetCache(t, res);
    return res;
 }
@@ -1185,12 +1186,6 @@ Term_p WHNF_step(TB_p bank, Term_p t)
    {
       res = whnf_step_uncached(bank, t);
    }
-   //printf("### WHNF: ");
-   //TermPrintDbg(stdout, t, bank->sig, DEREF_NEVER);
-   //printf(" => ");
-   //TermPrintDbg(stdout, res, bank->sig, DEREF_NEVER);
-   //printf("\n");
-
    return res;
 }
 

--- a/TERMS/cte_termbanks.c
+++ b/TERMS/cte_termbanks.c
@@ -1016,6 +1016,16 @@ Term_p TBInsertNoProps(TB_p bank, Term_p term, DerefType deref)
    t = problemType == PROBLEM_HO && deref == DEREF_ALWAYS ?
       WHNF_deref(term) : TermDeref(term, &deref);
    TermSetBank(term, tmp_bank);
+#ifdef ENABLE_LFHO
+   // Clear WHNF cache if WHNF_deref set it using the temporary bank (cross-bank
+   // pollution). The term lives in tmp_bank but the cached result is allocated in
+   // bank. If bank is GC-swept independently (e.g. tmp_terms sweep), the cache
+   // pointer becomes dangling and causes a use-after-free.
+   if(bank != tmp_bank)
+   {
+      TermSetCache(term, NULL);
+   }
+#endif
    term = t;
 
    if(TermIsFreeVar(term))
@@ -2072,7 +2082,7 @@ void TBGCMarkTerm(TB_p bank, Term_p term)
             PStackPushP(stack, TermRWReplaceField(term));
          }
 
-         if(TermIsAppliedFreeVar(term) && TermGetCache(term))
+         if(TermGetCache(term))
          {
             PStackPushP(stack, TermGetCache(term));
          }


### PR DESCRIPTION
### Problem

Running `eprover-ho` on TPTP problem `0112_Transcendental_01863` crashes
non-deterministically (~50% of runs) with:

```
eprover: cte_lambda.c:673: do_beta_normalize_db: Assertion `TermIsShared(res)' failed.
```

The `res` returned from the WHNF cache has a corrupted `f_code` and `arity=0`,
consistent with a term that was freed and its memory reused.

### Affected problems

- TPTP `0112_Transcendental_01863` (Transcendental_Number_Theory)

### Root cause

`TBInsertNoProps` temporarily changes `term->owner_bank` to the destination
bank before calling `WHNF_deref` (the so-called "cheat"):

```c
TB_p tmp_bank = TermGetBank(term);           // e.g. state->terms
TermSetBank(term, bank);                     // cheat: set to tmp_terms
t = WHNF_deref(term);
TermSetBank(term, tmp_bank);                 // restore state->terms
```

When `bank = tmp_terms` and `term` is a lambda-headed phony app from
`state->terms`, `WHNF_deref` calls `WHNF_step(TermGetBank(term)=tmp_terms, term)`.
On a cache miss, `whnf_step_uncached(tmp_terms, term)` allocates the result `res`
in `tmp_terms` and stores it in `term->binding_cache`.

After the cheat restores `owner_bank = state->terms`, `term->binding_cache` holds
a cross-bank pointer into `tmp_terms`. `TBGCSweep(tmp_terms)` subsequently frees
`res`, leaving the `state->terms` term with a dangling `binding_cache`. The next
`WHNF_step` call returns the dangling pointer as a cache hit, causing the crash.

### Fix

In `TBInsertNoProps` (`TERMS/cte_termbanks.c`), clear `binding_cache` after
restoring the original bank when the banks differ:

```c
TermSetBank(term, tmp_bank);
#ifdef ENABLE_LFHO
if(bank != tmp_bank)
{
   TermSetCache(term, NULL);
}
#endif
```

Secondary fix: `TBGCMarkTerm` only followed `binding_cache` for applied-free-var
phony apps, but WHNF caches are set on lambda-headed phony apps. Changed to follow
`binding_cache` on any term that has one, so the main-bank GC marks cached results
correctly:

```c
// Before:
if(TermIsAppliedFreeVar(term) && TermGetCache(term))
// After:
if(TermGetCache(term))
```

Also adds `assert(TermIsShared(res))` before `TermSetCache` in
`whnf_step_uncached` to catch unshared results early.
